### PR TITLE
Add tags from History Summary (hisSize, hisStart, hisEnd)

### DIFF
--- a/nhaystack-rt/src/nhaystack/server/SpaceManager.java
+++ b/nhaystack-rt/src/nhaystack/server/SpaceManager.java
@@ -18,6 +18,9 @@ import javax.baja.driver.BDevice;
 import javax.baja.driver.BDeviceNetwork;
 import javax.baja.driver.point.BPointDeviceExt;
 import javax.baja.history.BHistoryConfig;
+import javax.baja.history.BHistoryId;
+import javax.baja.history.BHistorySummary;
+import javax.baja.history.BIHistory;
 import javax.baja.history.HistorySpaceConnection;
 import javax.baja.history.ext.BHistoryExt;
 import javax.baja.naming.BOrd;
@@ -289,6 +292,21 @@ public class SpaceManager
         }
 
         return null;
+    }
+
+    BHistorySummary lookupHistorySummary(BHistoryId historyId)
+    {
+        try (HistorySpaceConnection conn = service.getHistoryDb().getConnection(null))
+        {
+            BIHistory history = conn.getHistory(historyId);
+
+            if(history == null)
+                return null;
+            
+            BHistorySummary summary = conn.getSummary(history);
+            
+            return summary;
+        }
     }
 
     /**

--- a/nhaystack-rt/src/nhaystack/server/TagManager.java
+++ b/nhaystack-rt/src/nhaystack/server/TagManager.java
@@ -30,6 +30,7 @@ import javax.baja.history.BBooleanTrendRecord;
 import javax.baja.history.BEnumTrendRecord;
 import javax.baja.history.BHistoryConfig;
 import javax.baja.history.BHistoryId;
+import javax.baja.history.BHistorySummary;
 import javax.baja.history.BIHistory;
 import javax.baja.history.BNumericTrendRecord;
 import javax.baja.history.BStringTrendRecord;
@@ -67,6 +68,7 @@ import nhaystack.util.NHaystackConst;
 import nhaystack.util.SlotUtil;
 import org.projecthaystack.HBool;
 import org.projecthaystack.HCoord;
+import org.projecthaystack.HDateTime;
 import org.projecthaystack.HDict;
 import org.projecthaystack.HDictBuilder;
 import org.projecthaystack.HGrid;
@@ -708,6 +710,8 @@ public class TagManager implements NHaystackConst
             }
         }
 
+        addHistorySummaryTags(cfg, hdb);
+
         // add custom tags
         hdb.add(server.createCustomTags(cfg));
 
@@ -893,6 +897,8 @@ public class TagManager implements NHaystackConst
                 if (historyExt instanceof BCovHistoryExt)
                     hdb.add("hisInterpolate", "cov");
             }
+
+            addHistorySummaryTags(cfg, hdb);
         }
 
         // cur, writable
@@ -942,6 +948,27 @@ public class TagManager implements NHaystackConst
 
         // siteRef, equipRef
         addSiteEquipTags(point, hdb, tags);
+    }
+
+    private void addHistorySummaryTags(BHistoryConfig cfg, HDictBuilder hdb)
+    {
+        BHistorySummary summary = spaceMgr.lookupHistorySummary(cfg.getId());
+        if(summary != null)
+        {
+            int recordCount = summary.getRecordCount();
+            if(recordCount > 0)
+            {
+                hdb.add("hisSize", recordCount);
+
+                HTimeZone tz = server.fromBajaTimeZone(cfg.getTimeZone());
+
+                HDateTime hisStart = HDateTime.make(summary.getFirstTimestamp().getMillis(), tz);
+                HDateTime hisEnd = HDateTime.make(summary.getLastTimestamp().getMillis(), tz);
+
+                hdb.add("hisStart", hisStart);
+                hdb.add("hisEnd", hisEnd);
+            }
+        }
     }
 
     private static String axStatus(BStatus status)
@@ -1407,7 +1434,10 @@ public class TagManager implements NHaystackConst
         "enum",
         "equip",
         "his",
+        "hisEnd",
         "hisInterpolate",
+        "hisSize",
+        "hisStart",
         "id",
         "kind",
         "maxVal",


### PR DESCRIPTION
This PR adds additional history tags based on the history summary.

- `hisSize` from `RecordCount`
- `hisStart` from `FirstTimestamp`
- `hisEnd` from `LastTimestamp`

The additional tags are omitted if the history is empty or doesn't yet exist on disk (not enabled / synced).

Todo

- Write test cases
